### PR TITLE
Add a magic getter that returns null

### DIFF
--- a/nil.php
+++ b/nil.php
@@ -43,6 +43,11 @@ class Nil implements Nilish
         return (string)null;
     }
 
+    public function __get()
+    {
+    	return null;
+    }
+
     public function __sleep()
     {
         return array();


### PR DESCRIPTION
Implementing Issue #4.  This will prevent an undefined property notice if you attempt to access any property of Nil.
